### PR TITLE
Add support for Binance futures

### DIFF
--- a/basana/external/binance/client/__init__.py
+++ b/basana/external/binance/client/__init__.py
@@ -18,7 +18,7 @@ from typing import Any, Dict, Optional
 
 import aiohttp
 
-from . import base, margin, spot
+from . import base, margin, spot, futures
 from basana.core import token_bucket
 
 
@@ -52,6 +52,10 @@ class APIClient:
     @property
     def isolated_margin_account(self) -> margin.IsolatedMarginAccount:
         return margin.IsolatedMarginAccount(self._client)
+
+    @property
+    def futures_account(self) -> futures.FuturesAccount:
+        return futures.FuturesAccount(self._client)
 
     async def get_order_book(self, symbol: str, limit: Optional[int] = None) -> dict:
         params: Dict[str, Any] = {"symbol": symbol}

--- a/basana/external/binance/client/futures.py
+++ b/basana/external/binance/client/futures.py
@@ -1,0 +1,100 @@
+# Basana
+#
+# Copyright 2022 Gabriel Martin Becedillas Ruiz
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from decimal import Decimal
+from typing import Any, Dict, List, Optional
+
+from . import base
+
+
+class FuturesAccount:
+    def __init__(self, client: base.BaseClient):
+        self._client = client
+
+    async def create_order(
+            self, symbol: str, side: str, type: str, time_in_force: Optional[str] = None,
+            quantity: Optional[Decimal] = None, price: Optional[Decimal] = None,
+            stop_price: Optional[Decimal] = None, new_client_order_id: Optional[str] = None, **kwargs: Dict[str, Any]
+    ) -> dict:
+        params: Dict[str, Any] = {
+            "symbol": symbol,
+            "side": side,
+            "type": type,
+        }
+        base.set_optional_params(params, (
+            ("timeInForce", time_in_force),
+            ("quantity", quantity),
+            ("price", price),
+            ("stopPrice", stop_price),
+            ("newClientOrderId", new_client_order_id),
+        ))
+        params.update(kwargs)
+        return await self._client.make_request("POST", "/fapi/v1/order", data=params, send_sig=True)
+
+    async def query_order(
+            self, symbol: str, order_id: Optional[int] = None, orig_client_order_id: Optional[str] = None
+    ) -> dict:
+        assert (order_id is not None) ^ (orig_client_order_id is not None), \
+            "Either order_id or orig_client_order_id should be set"
+
+        params: Dict[str, Any] = {
+            "symbol": symbol,
+        }
+        base.set_optional_params(params, (
+            ("orderId", order_id),
+            ("origClientOrderId", orig_client_order_id),
+        ))
+        return await self._client.make_request("GET", "/fapi/v1/order", qs_params=params, send_sig=True)
+
+    async def get_open_orders(
+            self, symbol: Optional[str] = None
+    ) -> dict:
+        params: Dict[str, Any] = {}
+        if symbol is not None:
+            params["symbol"] = symbol
+        return await self._client.make_request("GET", "/fapi/v1/openOrders", qs_params=params, send_sig=True)
+
+    async def cancel_order(
+            self, symbol: str, order_id: Optional[int] = None, orig_client_order_id: Optional[str] = None
+    ) -> dict:
+        assert (order_id is not None) ^ (orig_client_order_id is not None), \
+            "Either order_id or orig_client_order_id should be set"
+
+        params: Dict[str, Any] = {
+            "symbol": symbol,
+        }
+        base.set_optional_params(params, (
+            ("orderId", order_id),
+            ("origClientOrderId", orig_client_order_id),
+        ))
+        return await self._client.make_request("DELETE", "/fapi/v1/order", qs_params=params, send_sig=True)
+
+    async def get_trades(self, symbol: str, order_id: Optional[int] = None) -> List[dict]:
+        params: Dict[str, Any] = {
+            "symbol": symbol,
+        }
+        if order_id is not None:
+            params["orderId"] = order_id
+        return await self._client.make_request("GET", "/fapi/v1/userTrades", qs_params=params, send_sig=True)
+
+    async def create_listen_key(self) -> dict:
+        return await self._client.make_request("POST", "/fapi/v1/listenKey", send_key=True)
+
+    async def keep_alive_listen_key(self, listen_key: str) -> dict:
+        params: Dict[str, Any] = {
+            "listenKey": listen_key,
+        }
+        return await self._client.make_request("PUT", "/fapi/v1/listenKey", send_key=True, data=params)

--- a/basana/external/binance/config.py
+++ b/basana/external/binance/config.py
@@ -38,6 +38,11 @@ DEFAULTS = {
                     "heartbeat": 15 * 60,
                 },
             },
+            "futures": {
+                "user_data_stream": {
+                    "heartbeat": 15 * 60,
+                },
+            },
         }
     }
 }

--- a/basana/external/binance/exchange.py
+++ b/basana/external/binance/exchange.py
@@ -20,7 +20,7 @@ import dataclasses
 
 import aiohttp
 
-from . import client, helpers, order_book, trades, spot, cross_margin, isolated_margin, websocket_mgr
+from . import client, helpers, order_book, trades, spot, cross_margin, isolated_margin, websocket_mgr, futures
 from basana.core import bar, dispatcher, enums, token_bucket
 from basana.core.pair import Pair, PairInfo
 
@@ -209,6 +209,11 @@ class Exchange:
     def isolated_margin_account(self) -> isolated_margin.Account:
         """Returns the isolated margin account."""
         return isolated_margin.Account(self._cli.isolated_margin_account, self._ws_mgr)
+
+    @property
+    def futures_account(self) -> futures.FuturesAccount:
+        """Returns the futures account."""
+        return futures.FuturesAccount(self._cli.futures_account, self._ws_mgr)
 
 
 def get_filter_from_symbol_info(symbol_info: dict, filter_type: str) -> Optional[dict]:

--- a/basana/external/binance/helpers.py
+++ b/basana/external/binance/helpers.py
@@ -93,3 +93,22 @@ def timestamp_to_datetime(timestamp: int) -> datetime.datetime:
 
 def datetime_to_timestamp(datetime: datetime.datetime) -> int:
     return int(dt.to_utc_timestamp(datetime) * 1e3)
+
+
+def futures_order_status_is_open(order_status: str) -> bool:
+    is_open = {
+        "NEW": True,
+        "PARTIALLY_FILLED": True,
+        "FILLED": False,
+        "CANCELED": False,
+        "EXPIRED": False,
+    }.get(order_status)
+    assert is_open is not None, "No mapping for {} order status".format(order_status)
+    return is_open
+
+
+def futures_side_to_order_operation(side: str) -> OrderOperation:
+    return {
+        "BUY": OrderOperation.BUY,
+        "SELL": OrderOperation.SELL,
+    }[side]

--- a/basana/external/binance/klines.py
+++ b/basana/external/binance/klines.py
@@ -55,3 +55,35 @@ class WebSocketEventSource(core_ws.ChannelEventSource):
 
 def get_channel(pair: Pair, interval: str) -> str:
     return "{}@kline_{}".format(helpers.pair_to_order_book_symbol(pair).lower(), interval)
+
+
+class FuturesBar(bar.Bar):
+    def __init__(self, pair: Pair, json: dict):
+        super().__init__(
+            helpers.timestamp_to_datetime(int(json["t"])), pair, Decimal(json["o"]), Decimal(json["h"]),
+            Decimal(json["l"]), Decimal(json["c"]), Decimal(json["v"])
+        )
+        self.pair: Pair = pair
+        self.json: dict = json
+
+
+# Generate BarEvents events from websocket messages for futures market.
+class FuturesWebSocketEventSource(core_ws.ChannelEventSource):
+    def __init__(self, pair: Pair, producer: event.Producer):
+        super().__init__(producer=producer)
+        self._pair: Pair = pair
+
+    async def push_from_message(self, message: dict):
+        kline_event = message["data"]
+        kline = kline_event["k"]
+        # Wait for the last update to the kline.
+        if kline["x"] is False:
+            return
+        self.push(bar.BarEvent(
+            helpers.timestamp_to_datetime(int(kline_event["E"])),
+            FuturesBar(self._pair, kline)
+        ))
+
+
+def get_futures_channel(pair: Pair, interval: str) -> str:
+    return "{}@kline_{}".format(helpers.pair_to_order_book_symbol(pair).lower(), interval)

--- a/basana/external/binance/websocket_mgr.py
+++ b/basana/external/binance/websocket_mgr.py
@@ -79,6 +79,13 @@ class WebsocketManager:
             channel, event_src_factory, cast(dispatcher.EventHandler, forward_if_order_event)
         )
 
+    def subscribe_to_futures_bar_events(self, pair: Pair, interval: str, event_handler: bar.BarEventHandler):
+        self._subscribe_to_ws_channel_events(
+            binance_ws.PublicChannel(klines.get_futures_channel(pair, interval)),
+            lambda ws_cli: klines.FuturesWebSocketEventSource(pair, ws_cli),
+            cast(dispatcher.EventHandler, event_handler)
+        )
+
     def _subscribe_to_ws_channel_events(
             self, channel: binance_ws.Channel,
             event_src_factory: Callable[[core_ws.WebSocketClient], core_ws.ChannelEventSource],


### PR DESCRIPTION
Add support for Binance futures.

* Add `futures` module import and `futures_account` property to `APIClient` class in `basana/external/binance/client/__init__.py`.
* Add `FuturesAccount` class with methods for futures account operations in `basana/external/binance/client/futures.py`.
* Add configuration for Binance futures in `basana/external/binance/config.py`.
* Add `futures_account` property to `Exchange` class in `basana/external/binance/exchange.py`.
* Add helper functions for Binance futures in `basana/external/binance/helpers.py`.
* Add support for futures market klines in `basana/external/binance/klines.py`.
* Add support for futures account in `WebsocketManager` class in `basana/external/binance/websocket_mgr.py`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/revanthstrakz/basana/pull/2?shareId=9538e572-d683-45fa-9bb4-950435a39006).